### PR TITLE
Added convenience default clean task

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "gulp-browserify": "^0.5.0",
     "gulp-concat": "^2.2.0",
     "gulp-watch": "^0.6.8",
+    "gulp-rimraf": "~0.1.0",
+    "gulp-ignore": "~1.1.0",
     "http-server": "^0.6.1",
     "lodash": "^2.4.1",
     "moment": "^2.6.0",

--- a/src/tasks/gulp.js
+++ b/src/tasks/gulp.js
@@ -8,6 +8,8 @@ var gulp = require('gulp');
 var path = require('path');
 var Q = require('q');
 var watch = require('gulp-watch');
+var ignore = require('gulp-ignore');
+var rimraf = require('gulp-rimraf');
 
 var cli = require('../cli');
 
@@ -129,6 +131,12 @@ function defineTasks(gulp) {
   });
 
   gulp.task('baked:watch', ['baked:watch:src', 'baked:watch:content']);
+
+  gulp.task('baked:clean', ['baked:init'], function() {
+    return gulp.src(config.options.dst_dir + '/**/*', { read: false })
+      .pipe(ignore(config.options.dst_dir + ' /.gitkeep'))
+      .pipe(rimraf());
+  });
 
   /* default tasks */
 


### PR DESCRIPTION
Added a simple default clean task to remove generated files. Can be used by typing `gulp baked:clean`
