### PR TITLE
Support custom `srcDir` or `dstDir` in gulp build

### DIFF
--- a/gulp.js
+++ b/gulp.js
@@ -43,10 +43,10 @@ var config = {};
 function init(cfg) {
   initialized = true;
   if (!cfg) cfg = {};
-  var argOptions = _.defaults({
+  var argOptions = _.defaults(cfg.options, {
     srcDir: "to_generate",
     dstDir: "generated"
-  }, cfg.options);
+  });
 
   // supports gulpfiles providing src_dir insteaf of srcDir to init()
   if (!argOptions.srcDir) { argOptions.srcDir = argOptions.src_dir; }


### PR DESCRIPTION
You currently can't overwrite the `srcDir` or `dstDir` properties in gulp as the order of the arguments to `_.defaults` seems to be reversed. See: [https://lodash.com/docs#defaults](https://lodash.com/docs#defaults)

This PR reverses the arguments.
