### PR TITLE
argOptions isn't set if config.options is undefined

### DIFF
--- a/gulp.js
+++ b/gulp.js
@@ -43,7 +43,7 @@ var config = {};
 function init(cfg) {
   initialized = true;
   if (!cfg) cfg = {};
-  var argOptions = _.defaults(cfg.options, {
+  var argOptions = cfg.options = _.defaults({}, cfg.options, {
     srcDir: "to_generate",
     dstDir: "generated"
   });

--- a/gulp.js
+++ b/gulp.js
@@ -43,7 +43,7 @@ var config = {};
 function init(cfg) {
   initialized = true;
   if (!cfg) cfg = {};
-  var argOptions = cfg.options = _.defaults({}, cfg.options, {
+  var argOptions = _.defaults({}, cfg.options, {
     srcDir: "to_generate",
     dstDir: "generated"
   });


### PR DESCRIPTION
_.defaults doesnt work correctly if the first argument is undefined (https://github.com/lodash/lodash/blob/3.6.0/lodash.src.js#L9106)

This causes error `TypeError: Cannot read property 'srcDir' of undefined`.
