### PR TITLE
node api init object should override defaults

### DIFF
--- a/gulp.js
+++ b/gulp.js
@@ -53,7 +53,7 @@ function init(cfg) {
   if (!argOptions.dstDir) { argOptions.dstDir = argOptions.dst_dir; }
 
   var cliOptions = parseOptions();
-  var configuration = Configuration.readFromFileSync(_.assign(argOptions, cliOptions));
+  var configuration = Configuration.readFromFileSync(_.assign(cliOptions, argOptions));
 
   // supports gulpfiles using src_dir insteaf of srcDir from baked.config
   Object.defineProperty(configuration, "src_dir", {


### PR DESCRIPTION
Please see https://github.com/prismicio/baked.js/issues/26 for more information.
